### PR TITLE
Use system-defined OD search policy to find users

### DIFF
--- a/all/shellenv/_osx/open_directory.py
+++ b/all/shellenv/_osx/open_directory.py
@@ -109,7 +109,7 @@ def get_user_login_shell(username=None):
         node = OpenDirectory.ODNodeCreateWithName(
             CoreFoundation.kCFAllocatorDefault,
             session,
-            unicode_to_cfstring("/Local/Default"),
+            unicode_to_cfstring("/Search"),
             byref(error_ref)
         )
         if bool(error_ref):


### PR DESCRIPTION
Open Directory is configured with a Search Policy on OD clients (configured in Directory Utility.app). The search policy is a list of directories to search in order, which normally includes the local directory /Local/Default, but may also include Open Directory servers and Active Directory servers. The search policy is used by the system when authenticating and looking up users, groups, etc.

Querying /Local/Default only finds local users, so if I'm logged in to Mac OS using a network account from Active Directory, for example, my user won't be found. This leads to a crash in get_shell_env() when the shell returned from get_user_login_shell() is None.

Querying /Search seems to fix this as it instructs the OD client to search using the search policy for users, so it finds both local user accounts and network accounts.